### PR TITLE
Fix "map" alias

### DIFF
--- a/src/koans/relationships.sql
+++ b/src/koans/relationships.sql
@@ -13,6 +13,6 @@ where b.id = 1
 -- Meditate on MANY-TO-MANY relationships
 select a.first_name, a.last_name, b.title
 from book b
-	join book_to_author_map map on _____.id = _____.book_id
+	join book_to_author_map btam on _____.id = _____.book_id
 	join author a on _____.author_id = _____.id
 where author_id in (1, 5, 6)


### PR DESCRIPTION
Changed alias "map" to "btam", clarified ambiguity because "map" is highlighted
as a keyword by Emacs SQL mode.

See: https://stackoverflow.com/questions/40112411/what-is-the-map-keyword-in-sql