### PR TITLE
Remove unnecessary join in first subquery example

### DIFF
--- a/src/koans/solutions/subqueries.sql
+++ b/src/koans/solutions/subqueries.sql
@@ -1,8 +1,7 @@
 -- Meditate on using subqueries with IN
 select * from event
 where customer_id in (
-	select c.id from event
-		join customer c on event.customer_id = c.id
+	select customer_id from event
 	where type = 'Lost'
 )
 order by datetime desc

--- a/src/koans/solutions/subqueries.sql
+++ b/src/koans/solutions/subqueries.sql
@@ -8,12 +8,11 @@ order by datetime desc
 
 -- Meditate on WITH to create a Common Table Expression query
 with book_losers as (
-	select c.id from event
-		join customer c on event.customer_id = c.id
+	select customer_id from event
 	where type = 'Lost'
 )
 select e.* from book_losers bl
-	join event e on bl.id = e.customer_id
+	join event e on bl.customer_id = e.customer_id
 order by datetime desc
 
 -- Meditate on using subqueries for deleting data

--- a/src/koans/subqueries.sql
+++ b/src/koans/subqueries.sql
@@ -8,12 +8,11 @@ order by datetime desc
 
 -- Meditate on WITH to create a Common Table Expression query
 _____ book_losers as (
-	select c.id from event
-		join customer c on event.customer_id = c.id
+	select customer_id from event
 	where type = 'Lost'
 )
 select e.* from book_losers bl
-	join event e on bl.id = e.customer_id
+	join event e on bl.customer_id = e.customer_id
 order by datetime desc
 
 -- Meditate on using subqueries for deleting data

--- a/src/koans/subqueries.sql
+++ b/src/koans/subqueries.sql
@@ -1,8 +1,7 @@
 -- Meditate on using subqueries with IN
 select * from event
 where customer_id _____ (
-	select c.id from event
-		join customer c on event.customer_id = c.id
+	select customer_id from event
 	where type = 'Lost'
 )
 order by datetime desc


### PR DESCRIPTION
Removing this `join` doesn't affect the result of the query and shrinks
the example.  The `join` may help students differentiate between the
main and subquery, so it could be left in, but I think it clutters the
example more than necessary.